### PR TITLE
IR Serial Port Improvements

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -8,12 +8,12 @@
 1. Install dependencies:
    * Ubuntu:
      * All versions: `sudo apt install cmake extra-cmake-modules libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev libarchive-dev libenet-dev libzstd-dev`
-     * 24.04: `sudo apt install qt6-{base,base-private,multimedia,svg}-dev`
-     * 22.04: `sudo apt install qtbase6-dev qtbase6-private-dev qtmultimedia6-dev libqt6svg6-dev`
-     * Older versions: `sudo apt install qtbase5-dev qtbase5-private-dev qtmultimedia5-dev libqt5svg5-dev`  
+     * 24.04: `sudo apt install qt6-{base,base-private,multimedia,svg,serialport}-dev`
+     * 22.04: `sudo apt install qtbase6-dev qtbase6-private-dev qtmultimedia6-dev libqt6svg6-dev qt-serialport-dev`
+     * Older versions: `sudo apt install qtbase5-dev qtbase5-private-dev qtmultimedia5-dev libqt5svg5-dev qt5-serialport-dev`  
        Also add `-DUSE_QT6=OFF` to the first CMake command below.
-   * Fedora: `sudo dnf install gcc-c++ cmake extra-cmake-modules SDL2-devel libarchive-devel enet-devel libzstd-devel qt6-{qtbase,qtbase-private,qtmultimedia,qtsvg}-devel wayland-devel`
-   * Arch Linux: `sudo pacman -S base-devel cmake extra-cmake-modules git libpcap sdl2 qt6-{base,multimedia,svg} libarchive enet zstd`
+   * Fedora: `sudo dnf install gcc-c++ cmake extra-cmake-modules SDL2-devel libarchive-devel enet-devel libzstd-devel qt6-{qtbase,qtbase-private,qtmultimedia,qtsvg,serialport}-devel wayland-devel`
+   * Arch Linux: `sudo pacman -S base-devel cmake extra-cmake-modules git libpcap sdl2 qt6-{base,multimedia,svg,serialport} libarchive enet zstd`
 2. Download the melonDS repository and prepare:
    ```bash
    git clone https://github.com/melonDS-emu/melonDS
@@ -44,7 +44,7 @@
    ```
 6. Install Qt and configure the build directory
    * Dynamic builds (with DLLs)
-     1. Install Qt: `pacman -S <prefix>-{qt6-base,qt6-svg,qt6-multimedia,qt6-svg,qt6-tools}`
+     1. Install Qt: `pacman -S <prefix>-{qt6-base,qt6-svg,qt6-multimedia,qt6-svg,qt6-tools,qt6-serialport}`
      2. Set up the build directory with `cmake -B build`
    * Static builds (without DLLs, standalone executable)
      1. Install Qt: `pacman -S <prefix>-qt5-static`  
@@ -53,6 +53,13 @@
 7. Compile: `cmake --build build`
 
 If everything went well, melonDS should now be in the `build` folder. For dynamic builds, you may need to run melonDS from the MSYS2 terminal in order for it to find the required DLLs.
+> [!Note]
+> I've had decent luck with using the following compilation commands below. I have the `rm -rf build` command because I like to have a clean build folder while I am testing...
+```sh
+rm -rf build
+cmake -B build -DENABLE_LTO_RELEASE=OFF
+cmake --build build
+```
 
 ## macOS
 1. Install the [Homebrew Package Manager](https://brew.sh)

--- a/src/frontend/qt_sdl/IR/IRSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/IR/IRSettingsDialog.cpp
@@ -89,7 +89,16 @@ IRSettingsDialog::IRSettingsDialog(QWidget* parent) : QDialog(parent), ui(new Ui
     ui->txtEepromFile->setText(cfg.GetQString("IR.EEPROMPath"));
     //ui->textSerialPath->text());
 
-
+    // Load TCP settings
+    ui->boxHostIP->setText(cfg.GetQString("IR.TCP.HostIP"));
+    ui->boxSelfPort->setValue(cfg.GetInt("IR.TCP.SelfPort"));
+    ui->txtHostPort->setValue(cfg.GetInt("IR.TCP.HostPort"));
+    bool isTCPServer = cfg.GetBool("IR.TCP.IsServer");
+    if (isTCPServer) {
+        ui->rb_TCPServer->setChecked(true);
+    } else {
+        ui->rb_TCPClient->setChecked(true);
+    }
 
     toggleCompatSettings(ui->rbCompat->isChecked());
     toggleSerialSettings(ui->rbSerial->isChecked());
@@ -254,7 +263,11 @@ void IRSettingsDialog::done(int r)
 
         cfg.SetQString("IR.EEPROMPath", ui->txtEepromFile->text());
 
-
+        // Save TCP settings
+        cfg.SetQString("IR.TCP.HostIP", ui->boxHostIP->text());
+        cfg.SetInt("IR.TCP.SelfPort", ui->boxSelfPort->value());
+        cfg.SetInt("IR.TCP.HostPort", ui->txtHostPort->value());
+        cfg.SetBool("IR.TCP.IsServer", ui->rb_TCPServer->isChecked());
 
 
       //  auto& cfg = emuInstance->getGlobalConfig();

--- a/src/frontend/qt_sdl/IR/IRSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/IR/IRSettingsDialog.cpp
@@ -108,7 +108,7 @@ IRSettingsDialog::IRSettingsDialog(QWidget* parent) : QDialog(parent), ui(new Ui
 
 
 
-    ui->lblSelfIP->setText(QString("000.000.0.0"));
+    ui->lblSelfIP->setText(QString("0.0.0.0"));
 
     ui->txtDevLog->setText(cfg.GetQString("IR.PacketLogFile"));
 

--- a/src/frontend/qt_sdl/IR/IRSettingsDialog.ui
+++ b/src/frontend/qt_sdl/IR/IRSettingsDialog.ui
@@ -105,6 +105,9 @@
          <property name="title">
           <string>Direct Settings</string>
          </property>
+         <property name="toolTip">
+          <string>WARNING!!! Experimental, Backup your save before using!!!</string>
+         </property>
          <layout class="QGridLayout" name="gridLayout_4">
           <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignVCenter">
            <widget class="QPathInput" name="txtEepromFile"/>

--- a/src/frontend/qt_sdl/IR/IRSettingsDialog.ui
+++ b/src/frontend/qt_sdl/IR/IRSettingsDialog.ui
@@ -134,6 +134,9 @@
          <property name="title">
           <string>Serial Port Settings</string>
          </property>
+         <property name="toolTip">
+          <string>Switch between Compatibility and Serial to reset connection</string>
+         </property>
          <layout class="QGridLayout" name="gridLayout_3">
           <item row="1" column="0">
            <widget class="QLabel" name="labelPort">


### PR DESCRIPTION
## Summary
Made some improvements for the Serial Port integration for instances of Windows users having `COM`# greater than 9. It's an approach that is more user friendly. There are some lingering logging which can be removed if you wish but I needed a way to debug the communication between melon DS and my picowalker.

## Changes
- **Serial Port Integration:** Added comprehensive serial port communication support with connection management, error handling, and reconnection logic
- **IR Settings UI Enhancements:** Added tooltip hints and new configuration options in the IR settings dialog
- **Pokemon Staging Area:** Fixed some staging area issues in PokeEscalator (note: walk functionality still has known issues)
- **Build Documentation:** Updated BUILD.md with improved instructions

## Files Changed
- `src/frontend/qt_sdl/IR/IR.cpp` - Major serial port bug fixes and communication improvements
- `src/frontend/qt_sdl/IR/IRSettingsDialog.cpp` & `.ui` - UI enhancements and tooltip additions
- `src/frontend/qt_sdl/IR/PokeEscalator.cpp` - Staging area fixes
- `BUILD.md` - Documentation updates

## Known Issues
- Walk functionality in PokeEscalator still has issues that need to be addressed